### PR TITLE
Register dapp on first start

### DIFF
--- a/src/orchestration/conductor.js
+++ b/src/orchestration/conductor.js
@@ -8,14 +8,23 @@ let Conductor = function (service, config) {
   this.service = service
   this.config = config
 
+  this.timesStarted = 0
+
   let watcher = DI.container.get(DI.FILETYPES.Watcher)
   watcher.watch()
 
   this.orchestrate = () => {
     return Promise.delay(100)
       .then(() => {
-        logger.info('waiting for file changes...')
-        return watcher.waitForFileChanges()
+        if (this.timesStarted === 0) {
+          this.timesStarted++
+          logger.info('register dapp...')
+          return Promise.delay(0)
+        } else {
+          this.timesStarted++
+          logger.info('waiting for file changes...')
+          return watcher.waitForFileChanges()
+        }
       })
       .then(() => {
         logger.info('finished watching files...')


### PR DESCRIPTION
__New:__
This pull request registers a Dapp immediately after the start of `asch-redeploy`.

__Before:__
Before has a Dapp only been registered after a smart contract file has been changed.
