### PR TITLE
Add darwin platform to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "asch-redeploy": "./bin/asch-redeploy"
   },
   "os": [
-    "linux"
+    "linux",
+    "darwin"
   ],
   "engines": {
     "node": ">=7.0"


### PR DESCRIPTION
We should support darwin platform.

```bash
$ npm install -g asch-redeploy
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for asch-redeploy@1.0.4: wanted {"os":"linux","arch":"any"} (current: {"os":"darwin","arch":"x64"})
npm ERR! notsup Valid OS:    linux
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   darwin
npm ERR! notsup Actual Arch: x64

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cat/.npm/_logs/2019-05-01T13_20_13_247Z-debug.log
```

I have tested installation using my fork of `asch-redeploy`.

```bash
$ npm install -g git+https://github.com/bosoncat/asch-redeploy.git
```